### PR TITLE
Add multilevel locking

### DIFF
--- a/database/command/commit.go
+++ b/database/command/commit.go
@@ -2,8 +2,6 @@ package command
 
 import (
 	"io"
-
-	"github.com/jungnoh/mora/page"
 )
 
 type CommitCommand struct {
@@ -25,12 +23,12 @@ func (e *CommitCommand) TypeId() CommandType {
 	return CommitCommandType
 }
 
-func (e *CommitCommand) TargetSets() []page.CandleSet {
-	return []page.CandleSet{}
+func (e *CommitCommand) NeededLocks() []NeededLock {
+	return []NeededLock{}
 }
 
-func (e *CommitCommand) Persist(_ PageSetAccessor) error {
-	return nil
+func (e *CommitCommand) Execute(_ PageSetAccessor) (interface{}, error) {
+	return struct{}{}, nil
 }
 
 func (e *CommitCommand) String() string {

--- a/database/command/types.go
+++ b/database/command/types.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"github.com/jungnoh/mora/common"
+	"github.com/jungnoh/mora/database/concurrency"
 	"github.com/jungnoh/mora/page"
 )
 
@@ -19,14 +20,19 @@ type Command struct {
 }
 
 type PageSetAccessor interface {
-	Acquire(set page.CandleSet) (func(), error)
-	Get(set page.CandleSet) (*page.Page, error)
+	AcquirePage(set page.CandleSet, exclusive bool) (func(), error)
+	GetPage(set page.CandleSet, exclusive bool) (*page.Page, error)
+}
+
+type NeededLock struct {
+	Lock      concurrency.ResourceName
+	Exclusive bool
 }
 
 type CommandContent interface {
 	common.SizableBinaryReadWriter
 	TypeId() CommandType
-	TargetSets() []page.CandleSet
-	Persist(accessor PageSetAccessor) error
+	NeededLocks() []NeededLock
+	Execute(accessor PageSetAccessor) (interface{}, error)
 	String() string
 }

--- a/database/concurrency/counter.go
+++ b/database/concurrency/counter.go
@@ -1,0 +1,107 @@
+package concurrency
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type ChildSet struct {
+	accessLock sync.Mutex
+
+	children map[ResourceNamePart]*MultiLevelLock
+	// map[ResourceNamePart]struct{} used as a set
+	txChildren map[TransactionId]map[ResourceNamePart]struct{}
+}
+
+func NewTransactionRefCounter() *ChildSet {
+	return &ChildSet{
+		children:   make(map[ResourceNamePart]*MultiLevelLock),
+		txChildren: make(map[TransactionId]map[ResourceNamePart]struct{}),
+	}
+}
+
+func (t *ChildSet) AddChild(ptr *MultiLevelLock) {
+	t.accessLock.Lock()
+	defer t.accessLock.Unlock()
+
+	childKey := ptr.lastNamePart
+	if v, ok := t.children[childKey]; ok && v != ptr {
+		panic(errors.Errorf("cannot add child '%s' twice", childKey))
+	}
+	t.children[childKey] = ptr
+}
+
+func (t *ChildSet) RemoveChild(childKey ResourceNamePart) {
+	t.accessLock.Lock()
+	defer t.accessLock.Unlock()
+
+	if _, ok := t.children[childKey]; ok {
+		panic(errors.Errorf("child '%s' does not exist", childKey))
+	}
+	delete(t.children, childKey)
+}
+
+func (t *ChildSet) AddReference(txId TransactionId, childKey ResourceNamePart) {
+	t.accessLock.Lock()
+	defer t.accessLock.Unlock()
+
+	if _, ok := t.children[childKey]; !ok {
+		panic(errors.Errorf("child '%s' does not exist", childKey))
+	}
+	if _, ok := t.txChildren[txId]; !ok {
+		t.txChildren[txId] = make(map[ResourceNamePart]struct{})
+	}
+	t.txChildren[txId][childKey] = struct{}{}
+}
+
+func (t *ChildSet) RemoveReference(txId TransactionId, childKey ResourceNamePart) {
+	t.accessLock.Lock()
+	defer t.accessLock.Unlock()
+
+	if _, ok := t.children[childKey]; !ok {
+		panic(errors.Errorf("child '%s' does not exist", childKey))
+	}
+	if _, ok := t.txChildren[txId]; !ok {
+		t.txChildren[txId] = make(map[ResourceNamePart]struct{})
+	}
+	delete(t.txChildren[txId], childKey)
+}
+
+func (t *ChildSet) ClearReferences(txId TransactionId) {
+	t.accessLock.Lock()
+	defer t.accessLock.Unlock()
+	delete(t.txChildren, txId)
+}
+
+func (t *ChildSet) TransactionCount(txId TransactionId) int {
+	t.accessLock.Lock()
+	defer t.accessLock.Unlock()
+
+	if _, ok := t.txChildren[txId]; ok {
+		return len(t.txChildren[txId])
+	}
+	return 0
+}
+
+func (t *ChildSet) TransactionChildren(txId TransactionId) []*MultiLevelLock {
+	t.accessLock.Lock()
+	defer t.accessLock.Unlock()
+
+	if children, ok := t.txChildren[txId]; ok {
+		ret := make([]*MultiLevelLock, 0, len(children))
+		for child := range children {
+			if _, childOk := t.children[child]; !childOk {
+				panic(errors.Errorf("child '%s' does not exist", child))
+			}
+			ret = append(ret, t.children[child])
+		}
+		return ret
+	}
+	return []*MultiLevelLock{}
+}
+
+func (t *ChildSet) String() string {
+	return fmt.Sprintf("TransactionRefCounter(%d children, %d tx)", len(t.children), len(t.txChildren))
+}

--- a/database/concurrency/db.go
+++ b/database/concurrency/db.go
@@ -1,0 +1,150 @@
+package concurrency
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog/log"
+)
+
+type multiLevelLockSet struct {
+	accessLock sync.Mutex
+	manager    *LockManager
+	rootLock   *MultiLevelLock
+	locks      map[uint64]*MultiLevelLock
+}
+
+func newMultiLevelLockSet(manager *LockManager) *multiLevelLockSet {
+	rootLock := NewMultiLevelLock(manager, nil, NewResourceNamePart("db"))
+	locks := make(map[uint64]*MultiLevelLock)
+	locks[rootLock.name.hashValue] = rootLock
+	return &multiLevelLockSet{
+		manager:  manager,
+		rootLock: rootLock,
+		locks:    locks,
+	}
+}
+
+func (m *multiLevelLockSet) Get(resource ResourceName) *MultiLevelLock {
+	m.accessLock.Lock()
+	defer m.accessLock.Unlock()
+
+	wantedKeys := make([]ResourceNamePart, len(resource.Parts)+1)
+	copy(wantedKeys[1:], resource.Parts)
+	wantedKeys[0] = NewResourceNamePart("db")
+
+	var parentLock *MultiLevelLock = nil
+	partIndex := len(wantedKeys)
+	for ; partIndex >= 0; partIndex-- {
+		resourceName := NewResourceName(wantedKeys[0:partIndex])
+		if lock, ok := m.locks[resourceName.hashValue]; ok {
+			parentLock = lock
+			break
+		}
+	}
+	for i := partIndex; i < len(wantedKeys); i++ {
+		parentLock = NewMultiLevelLock(m.manager, parentLock, wantedKeys[i])
+		m.locks[parentLock.name.hashValue] = parentLock
+	}
+	return parentLock
+}
+
+type DatabaseLock struct {
+	manager *LockManager
+	lockSet *multiLevelLockSet
+}
+
+func NewDatabaseLock() *DatabaseLock {
+	manager := LockManager{
+		txLocks: TransactionLockMap{
+			data: make(map[TransactionId]map[uint64][]LockType),
+		},
+		entries: make(map[uint64]*LockEntry),
+	}
+	return &DatabaseLock{
+		manager: &manager,
+		lockSet: newMultiLevelLockSet(&manager),
+	}
+}
+
+func (d *DatabaseLock) EnsureLock(txId TransactionId, resource ResourceName, lockType LockType) error {
+	if lockType == NoLock {
+		return nil
+	}
+	if lockType != SLock && lockType != XLock {
+		return errors.Errorf("unexpected lock type '%s'", lockType)
+	}
+
+	lock := d.lockSet.Get(resource)
+	explicitLockType := lock.manager.LockType(txId, lock.name)
+	effectiveLockType := lock.EffectiveLockType(txId)
+	if effectiveLockType.CanSubsitute(lockType) {
+		log.Debug().Uint64("txId", uint64(txId)).Stringer("resource", resource).Stringer("type", lockType).Msg("lock changes not necessary")
+		return nil
+	}
+
+	if explicitLockType != NoLock {
+		if err := lock.Esclate(txId); err != nil {
+			return errors.Wrap(err, "failed to esclate")
+		}
+		lockTypeAfterEsclate := lock.LockType(txId)
+		if lockTypeAfterEsclate != SLock && lockTypeAfterEsclate != XLock {
+			panic(errors.Errorf("lock for '%s' esclated but not S/X", lock.name))
+		}
+		if lockTypeAfterEsclate == SLock && lockType == XLock {
+			if err := lock.Promote(txId, XLock); err != nil {
+				return errors.Wrap(err, "failed to promote S->X after esclation")
+			}
+		}
+		return nil
+	}
+
+	if lockType == SLock {
+		return d.acquireSIntent(txId, lock)
+	}
+	return d.acquireXIntent(txId, lock)
+}
+
+func (d *DatabaseLock) acquireSIntent(txId TransactionId, lock *MultiLevelLock) error {
+	lockType := lock.LockType(txId)
+	if lockType == SLock || lockType == SIXLock || lockType == XLock {
+		panic(errors.Errorf("unexpected ancestor lock '%s' while acquiring IS", lockType))
+	}
+	// Ancestors already have intent if IS or IX
+	if lockType != NoLock {
+		return nil
+	}
+	if lock.parent != nil {
+		if err := d.acquireSIntent(txId, lock.parent); err != nil {
+			return err
+		}
+	}
+	return lock.Acquire(txId, ISLock)
+}
+
+func (d *DatabaseLock) acquireXIntent(txId TransactionId, lock *MultiLevelLock) error {
+	lockType := lock.LockType(txId)
+	if lockType == XLock {
+		panic(errors.Errorf("unexpected ancestor lock '%s' while acquiring IX", lockType))
+	}
+	// Ancestors already have intent if IX or SIX
+	if lockType == IXLock || lockType == SIXLock {
+		return nil
+	}
+	if lock.parent != nil {
+		if err := d.acquireXIntent(txId, lock.parent); err != nil {
+			return err
+		}
+	}
+	if lockType == ISLock {
+		return lock.Promote(txId, IXLock)
+	}
+	if lockType == SLock {
+		return lock.Promote(txId, SIXLock)
+	}
+	return lock.Acquire(txId, IXLock)
+}
+
+func (d *DatabaseLock) Free(txId TransactionId) error {
+	return d.manager.ReleaseAll(txId)
+}

--- a/database/concurrency/db.go
+++ b/database/concurrency/db.go
@@ -158,3 +158,7 @@ func (d *DatabaseLock) acquireXIntent(txId TransactionId, lock *MultiLevelLock) 
 func (d *DatabaseLock) Free(txId TransactionId) error {
 	return d.manager.ReleaseAll(txId)
 }
+
+func (d *DatabaseLock) PrintAllLocks() {
+	d.lockSet.rootLock.PrintAllLocks()
+}

--- a/database/concurrency/lock.go
+++ b/database/concurrency/lock.go
@@ -1,0 +1,88 @@
+package concurrency
+
+import "sync"
+
+type Lock struct {
+	Name        ResourceName
+	Transaction TransactionId
+	Type        LockType
+}
+
+type LockList []Lock
+
+func (l LockList) Contains(lock Lock) bool {
+	for _, v := range l {
+		if v.Name == lock.Name && v.Transaction == lock.Transaction && v.Type == lock.Type {
+			return true
+		}
+	}
+	return false
+}
+
+type TransactionLockMap struct {
+	data map[TransactionId]map[ResourceName][]LockType
+	lock sync.Mutex
+}
+
+func (m *TransactionLockMap) LockTypes(txId TransactionId, name ResourceName) []LockType {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if _, ok := m.data[txId]; !ok {
+		m.data[txId] = make(map[ResourceName][]LockType)
+		m.data[txId][name] = make([]LockType, 0)
+		return []LockType{}
+	}
+	if _, ok := m.data[txId][name]; !ok {
+		m.data[txId][name] = make([]LockType, 0)
+		return []LockType{}
+	}
+	return m.data[txId][name]
+}
+
+func (m *TransactionLockMap) Contains(lock Lock) bool {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if _, ok := m.data[lock.Transaction]; !ok {
+		m.data[lock.Transaction] = make(map[ResourceName][]LockType)
+		m.data[lock.Transaction][lock.Name] = make([]LockType, 0)
+		return false
+	}
+	if _, ok := m.data[lock.Transaction][lock.Name]; !ok {
+		m.data[lock.Transaction][lock.Name] = make([]LockType, 0)
+		return false
+	}
+	for _, v := range m.data[lock.Transaction][lock.Name] {
+		if v == lock.Type {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *TransactionLockMap) ContainsResource(txId TransactionId, name ResourceName) bool {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if _, ok := m.data[txId]; !ok {
+		m.data[txId] = make(map[ResourceName][]LockType)
+		m.data[txId][name] = make([]LockType, 0)
+		return false
+	}
+	if _, ok := m.data[txId][name]; !ok {
+		m.data[txId][name] = make([]LockType, 0)
+		return false
+	}
+	return len(m.data[txId][name]) > 0
+}
+
+func (m *TransactionLockMap) DeleteResource(txId TransactionId, name ResourceName) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if _, ok := m.data[txId]; !ok {
+		return
+	}
+	delete(m.data[txId], name)
+}

--- a/database/concurrency/lock.go
+++ b/database/concurrency/lock.go
@@ -25,6 +25,13 @@ type TransactionLockMap struct {
 	lock          sync.Mutex
 }
 
+func NewTransactionLockMap() TransactionLockMap {
+	return TransactionLockMap{
+		data:          make(map[TransactionId]map[uint64][]LockType),
+		resourceNames: make(map[uint64]ResourceName),
+	}
+}
+
 func (m *TransactionLockMap) LockTypes(txId TransactionId, name ResourceName) []LockType {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/database/concurrency/lock.go
+++ b/database/concurrency/lock.go
@@ -1,6 +1,8 @@
 package concurrency
 
-import "sync"
+import (
+	"sync"
+)
 
 type Lock struct {
 	Name        ResourceName
@@ -92,6 +94,22 @@ func (m *TransactionLockMap) ContainsResource(txId TransactionId, name ResourceN
 		return false
 	}
 	return len(m.data[txId][name.hashValue]) > 0
+}
+
+func (m *TransactionLockMap) AddLock(txId TransactionId, name ResourceName, lockType LockType) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if _, ok := m.resourceNames[name.hashValue]; !ok {
+		m.resourceNames[name.hashValue] = name
+	}
+	if _, ok := m.data[txId]; !ok {
+		m.data[txId] = make(map[uint64][]LockType)
+	}
+	if _, ok := m.data[txId][name.hashValue]; !ok {
+		m.data[txId][name.hashValue] = make([]LockType, 0)
+	}
+	m.data[txId][name.hashValue] = append(m.data[txId][name.hashValue], lockType)
 }
 
 func (m *TransactionLockMap) DeleteResource(txId TransactionId, name ResourceName) {

--- a/database/concurrency/lockEntry.go
+++ b/database/concurrency/lockEntry.go
@@ -1,6 +1,8 @@
 package concurrency
 
-import "sync"
+import (
+	"sync"
+)
 
 func NewLockEntry(name ResourceName, txLockMap *TransactionLockMap) *LockEntry {
 	return &LockEntry{
@@ -22,9 +24,8 @@ type LockEntry struct {
 func (l *LockEntry) TransactionLockType(txId TransactionId) LockType {
 	l.accessLock.Lock()
 	defer l.accessLock.Unlock()
-
 	lock, ok := l.locks[txId]
-	if ok {
+	if !ok {
 		return NoLock
 	}
 	return lock.Type

--- a/database/concurrency/lockEntry.go
+++ b/database/concurrency/lockEntry.go
@@ -1,0 +1,90 @@
+package concurrency
+
+import "sync"
+
+func NewLockEntry(name ResourceName, txLockMap *TransactionLockMap) *LockEntry {
+	return &LockEntry{
+		name:      name,
+		locks:     make(map[TransactionId]Lock, 0),
+		queue:     newLockQueue(),
+		txLockMap: txLockMap,
+	}
+}
+
+type LockEntry struct {
+	accessLock sync.Mutex
+	name       ResourceName
+	locks      map[TransactionId]Lock
+	queue      lockQueue
+	txLockMap  *TransactionLockMap
+}
+
+func (l *LockEntry) TransactionLockType(txId TransactionId) LockType {
+	l.accessLock.Lock()
+	defer l.accessLock.Unlock()
+
+	lock, ok := l.locks[txId]
+	if ok {
+		return NoLock
+	}
+	return lock.Type
+}
+
+func (l *LockEntry) Release(txId TransactionId) {
+	l.accessLock.Lock()
+	defer l.accessLock.Unlock()
+
+	delete(l.locks, txId)
+	l.txLockMap.DeleteResource(txId, l.name)
+	l.processQueue()
+}
+
+func (l *LockEntry) LockCompatible(lockType LockType, txId TransactionId) bool {
+	l.accessLock.Lock()
+	defer l.accessLock.Unlock()
+
+	return l.lockCompatible(lockType, txId)
+}
+
+func (l *LockEntry) AddToQueue(request lockRequest, front bool) {
+	l.accessLock.Lock()
+	defer l.accessLock.Unlock()
+
+	if !l.queue.HasNext() && l.lockCompatible(request.Lock.Type, request.Lock.Transaction) {
+		l.grantLock(request.Lock)
+		request.Ack <- true
+		return
+	}
+	if front {
+		l.queue.PushFront(request)
+	} else {
+		l.queue.PushEnd(request)
+	}
+}
+
+func (l *LockEntry) processQueue() {
+	popped := l.queue.PopMatching(func(item *lockRequest) bool {
+		return l.lockCompatible(item.Lock.Type, item.Lock.Transaction)
+	})
+	if popped == nil {
+		return
+	}
+	l.grantLock(popped.Lock)
+	popped.Ack <- true
+}
+
+func (l *LockEntry) grantLock(lock Lock) {
+	l.locks[lock.Transaction] = lock
+}
+
+func (l *LockEntry) lockCompatible(lockType LockType, txId TransactionId) bool {
+	for _, lock := range l.locks {
+		if !lockType.Compatible(lock.Type) {
+			if lock.Transaction == txId {
+				continue
+			}
+			return false
+		}
+	}
+	return true
+}

--- a/database/concurrency/lockManager.go
+++ b/database/concurrency/lockManager.go
@@ -35,6 +35,7 @@ func (l *LockManager) Acquire(txId TransactionId, name ResourceName, lockType Lo
 	}
 	go resource.AddToQueue(lockRequest{Lock: wantedLock, Ack: ack}, false)
 	<-ack
+	l.txLocks.AddLock(txId, name, lockType)
 	return nil
 }
 
@@ -54,6 +55,7 @@ func (l *LockManager) AcquireThenRelease(txId TransactionId, name ResourceName, 
 	ack := make(chan bool)
 	go resource.AddToQueue(lockRequest{Lock: wantedLock, Ack: ack}, false)
 	<-ack
+	l.txLocks.AddLock(txId, name, lockType)
 
 	for _, release := range releases {
 		if err := l.Release(txId, release); err != nil {

--- a/database/concurrency/lockManager.go
+++ b/database/concurrency/lockManager.go
@@ -1,0 +1,66 @@
+package concurrency
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type LockManager struct {
+	txLocks     TransactionLockMap
+	entries     map[ResourceName]*LockEntry
+	entriesLock sync.Mutex
+}
+
+func (l *LockManager) getResourceEntry(name ResourceName) *LockEntry {
+	l.entriesLock.Lock()
+	defer l.entriesLock.Unlock()
+
+	if _, ok := l.entries[name]; !ok {
+		l.entries[name] = NewLockEntry(name, &l.txLocks)
+	}
+	return l.entries[name]
+}
+
+func (l *LockManager) Acquire(txId TransactionId, name ResourceName, lockType LockType) error {
+	wantedLock := Lock{Name: name, Transaction: txId, Type: lockType}
+	ack := make(chan bool)
+	resource := l.getResourceEntry(name)
+
+	if l.txLocks.Contains(wantedLock) {
+		return errors.Errorf("'%s' lock already held by this transaction", lockType)
+	}
+	go resource.AddToQueue(lockRequest{Lock: wantedLock, Ack: ack}, false)
+	<-ack
+	return nil
+}
+
+func (l *LockManager) Release(txId TransactionId, name ResourceName) error {
+	// TODO: Update LockManager map state
+	if l.txLocks.ContainsResource(txId, name) {
+		return errors.New("Transaction does not have lock on this resource")
+	}
+	resource := l.getResourceEntry(name)
+	resource.Release(txId)
+	return nil
+}
+
+func (l *LockManager) Promote(txId TransactionId, name ResourceName, newLockType LockType) error {
+	if !l.txLocks.ContainsResource(txId, name) {
+		return errors.New("Transaction does not have lock on this resource")
+	}
+	resourceEntry := l.getResourceEntry(name)
+	existingType := resourceEntry.TransactionLockType(txId)
+	if existingType == newLockType {
+		return errors.Errorf("Cannot promote equivalent lock (%s)", newLockType)
+	}
+	if !newLockType.CanSubsitute(existingType) {
+		return errors.Errorf("Cannot promote lock '%s' to '%s'", existingType, newLockType)
+	}
+
+	ack := make(chan bool)
+	wantedLock := Lock{Name: name, Transaction: txId, Type: newLockType}
+	go resourceEntry.AddToQueue(lockRequest{Lock: wantedLock, Ack: ack}, false)
+	<-ack
+	return nil
+}

--- a/database/concurrency/lockManager.go
+++ b/database/concurrency/lockManager.go
@@ -8,7 +8,7 @@ import (
 
 type LockManager struct {
 	txLocks     TransactionLockMap
-	entries     map[ResourceName]*LockEntry
+	entries     map[uint64]*LockEntry
 	entriesLock sync.Mutex
 }
 
@@ -16,10 +16,10 @@ func (l *LockManager) getResourceEntry(name ResourceName) *LockEntry {
 	l.entriesLock.Lock()
 	defer l.entriesLock.Unlock()
 
-	if _, ok := l.entries[name]; !ok {
-		l.entries[name] = NewLockEntry(name, &l.txLocks)
+	if _, ok := l.entries[name.hashValue]; !ok {
+		l.entries[name.hashValue] = NewLockEntry(name, &l.txLocks)
 	}
-	return l.entries[name]
+	return l.entries[name.hashValue]
 }
 
 func (l *LockManager) Acquire(txId TransactionId, name ResourceName, lockType LockType) error {

--- a/database/concurrency/lockManager.go
+++ b/database/concurrency/lockManager.go
@@ -59,7 +59,7 @@ func (l *LockManager) AcquireThenRelease(txId TransactionId, name ResourceName, 
 
 	for _, release := range releases {
 		if err := l.Release(txId, release); err != nil {
-			return errors.Wrapf(err, "error releasing (%d,%s)", txId, release)
+			return errors.Wrapf(err, "error releasing (%d, %s)", txId, release)
 		}
 	}
 	return nil
@@ -88,7 +88,7 @@ func (l *LockManager) Promote(txId TransactionId, name ResourceName, newLockType
 
 func (l *LockManager) Release(txId TransactionId, name ResourceName) error {
 	log.Debug().Uint64("txId", uint64(txId)).Stringer("resource", name).Msg("Release")
-	if l.txLocks.ContainsResource(txId, name) {
+	if !l.txLocks.ContainsResource(txId, name) {
 		return errors.New("Transaction does not have lock on this resource")
 	}
 	resource := l.getResourceEntry(name)

--- a/database/concurrency/lockQueue.go
+++ b/database/concurrency/lockQueue.go
@@ -1,0 +1,66 @@
+package concurrency
+
+import (
+	"sync"
+
+	"github.com/gammazero/deque"
+)
+
+type lockRequest struct {
+	Ack  chan<- bool
+	Lock Lock
+}
+
+type lockQueue struct {
+	queue *deque.Deque
+	lock  sync.Mutex
+}
+
+func newLockQueue() lockQueue {
+	return lockQueue{
+		queue: deque.New(),
+	}
+}
+
+func (l *lockQueue) PushFront(entry lockRequest) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	l.queue.PushFront(entry)
+}
+
+func (l *lockQueue) PushEnd(entry lockRequest) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	l.queue.PushBack(entry)
+}
+
+func (l *lockQueue) Pop() *lockRequest {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	if l.queue.Len() == 0 {
+		return nil
+	}
+	popped := l.queue.PopFront().(lockRequest)
+	return &popped
+}
+
+func (l *lockQueue) PopMatching(matcher func(item *lockRequest) bool) *lockRequest {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
+	index := l.queue.Index(func(i interface{}) bool {
+		entry := i.(lockRequest)
+		return matcher(&entry)
+	})
+	if index == -1 {
+		return nil
+	}
+	popped := l.queue.Remove(index).(lockRequest)
+	return &popped
+}
+
+func (l *lockQueue) HasNext() bool {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	return l.queue.Len() != 0
+}

--- a/database/concurrency/lockType.go
+++ b/database/concurrency/lockType.go
@@ -53,7 +53,7 @@ func LockTypesCanBeParent(parent, child LockType) bool {
 	return false
 }
 
-// LockTypesSubstitutable returns if a lock with type 'have' can be substitute a lock with type 'want'.
+// LockTypesSubstitutable returns if a lock with type 'have' can substitute a lock with type 'want'.
 func LockTypesSubstitutable(have, want LockType) bool {
 	if have == want {
 		return true

--- a/database/concurrency/lockType.go
+++ b/database/concurrency/lockType.go
@@ -1,0 +1,132 @@
+package concurrency
+
+type LockType uint8
+
+const (
+	NoLock  LockType = 0 // No lock held
+	ISLock  LockType = 1 // Intention shared
+	IXLock  LockType = 2 // Intention exclusive
+	SLock   LockType = 3 // Shared
+	SIXLock LockType = 4 // Shared intention exclusive
+	XLock   LockType = 5 // Exclusive
+)
+
+// LockTypesCompatible returns if locks of type l1 and l2 can applied to a resource at the same time.
+func LockTypesCompatible(l1, l2 LockType) bool {
+	if l1 == NoLock || l2 == NoLock {
+		return true
+	}
+	switch l1 {
+	case XLock:
+		return false
+	case SIXLock:
+		return l2 == ISLock
+	case SLock:
+		return l2 == SLock || l2 == ISLock
+	case IXLock:
+		return l2 == ISLock || l2 == IXLock
+	case ISLock:
+		return l2 != XLock
+	}
+	panic("invalid lock types")
+}
+
+// LockTypesCanBeParent returns if a parent with the given LockType can grant the given LockType to its child
+func LockTypesCanBeParent(parent, child LockType) bool {
+	if child == NoLock {
+		return true
+	}
+	switch parent {
+	case NoLock:
+		return false
+	case ISLock:
+		return child == SLock || child == ISLock
+	case IXLock:
+		return true
+	case SLock:
+		return !child.IsIntent()
+	case SIXLock:
+		return child == IXLock || child == XLock
+	case XLock:
+		return child == XLock || child == SLock
+	}
+	return false
+}
+
+// LockTypesSubstitutable returns if a lock with type 'have' can be substitute a lock with type 'want'.
+func LockTypesSubstitutable(have, want LockType) bool {
+	if have == want {
+		return true
+	}
+	switch want {
+	case NoLock:
+		return true
+	case ISLock:
+		return have == SLock || have == IXLock
+	case IXLock:
+		return have == XLock
+	case SLock:
+		return have == SIXLock || have == XLock
+	case SIXLock:
+		return have == SLock || have == IXLock
+	case XLock:
+		return false
+	}
+	return false
+}
+
+func (l LockType) Compatible(other LockType) bool {
+	return LockTypesCompatible(l, other)
+}
+
+func (l LockType) LockOfParent() LockType {
+	switch l {
+	case NoLock:
+		return NoLock
+	case ISLock:
+		return ISLock
+	case IXLock:
+		return IXLock
+	case SLock:
+		return ISLock
+	case SIXLock:
+		return IXLock
+	case XLock:
+		return IXLock
+	}
+	panic("unknown lock type")
+}
+
+func (l LockType) CanBeChildOf(parent LockType) bool {
+	return LockTypesCanBeParent(parent, l)
+}
+
+func (l LockType) CanBeParentOf(child LockType) bool {
+	return LockTypesCanBeParent(l, child)
+}
+
+func (l LockType) CanSubsitute(other LockType) bool {
+	return LockTypesSubstitutable(l, other)
+}
+
+func (l LockType) IsIntent() bool {
+	return l == IXLock || l == ISLock || l == SIXLock
+}
+
+func (l LockType) String() string {
+	switch l {
+	case NoLock:
+		return "NO"
+	case ISLock:
+		return "IS"
+	case IXLock:
+		return "IX"
+	case SLock:
+		return "S"
+	case SIXLock:
+		return "SIX"
+	case XLock:
+		return "X"
+	}
+	panic("unknown lock type")
+}

--- a/database/concurrency/multiLevelLock.go
+++ b/database/concurrency/multiLevelLock.go
@@ -1,0 +1,148 @@
+package concurrency
+
+import (
+	"github.com/pkg/errors"
+)
+
+// Hierarchy: Market -> Symbol -> Page
+
+type MultiLevelLock struct {
+	name                ResourceName
+	lastNamePart        ResourceNamePart
+	manager             *LockManager
+	parent              *MultiLevelLock
+	childrenLockCounter ChildSet
+}
+
+func traverseChildren(txId TransactionId, lock *MultiLevelLock, post *func(*MultiLevelLock) error) error {
+	for _, child := range lock.childrenLockCounter.TransactionChildren(txId) {
+		if err := traverseChildren(txId, child, post); err != nil {
+			return err
+		}
+	}
+	if post != nil {
+		if err := (*post)(lock); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func releaseLockIfSIS(txId TransactionId, lock *MultiLevelLock) error {
+	lockType := lock.manager.LockType(txId, lock.name)
+	if lockType == SLock || lockType == ISLock {
+		return lock.manager.Release(txId, lock.name)
+	}
+	return nil
+}
+
+//TODO: Race while creating lock with same key?
+func NewMultiLevelLock(manager *LockManager, parent *MultiLevelLock, key ResourceNamePart) *MultiLevelLock {
+	lock := MultiLevelLock{
+		manager:             manager,
+		parent:              parent,
+		childrenLockCounter: *NewTransactionRefCounter(),
+	}
+	if parent != nil && parent.manager != manager {
+		panic("parent and child have different managers")
+	}
+	if parent != nil {
+		lock.name = parent.name.Child(key)
+	} else {
+		lock.name = ResourceName(key)
+	}
+	return &lock
+}
+
+func (m *MultiLevelLock) Acquire(txId TransactionId, lockType LockType) error {
+	if m.parent != nil {
+		parentLockType := m.manager.LockType(txId, m.parent.name)
+		if !LockTypesCanBeParent(parentLockType, lockType) {
+			return errors.Errorf("incompatible lock type with parent (child %s, parent %s)", lockType, parentLockType)
+		}
+	}
+	if err := m.manager.Acquire(txId, m.name, lockType); err != nil {
+		return errors.Wrapf(err, "failed to lock (%s,%s,txId=%d)", m.name, lockType, txId)
+	}
+	if m.parent != nil {
+		m.parent.childrenLockCounter.AddChild(m)
+		m.parent.childrenLockCounter.AddReference(txId, m.lastNamePart)
+	}
+	return nil
+}
+
+func (m *MultiLevelLock) Release(txId TransactionId) error {
+	if count := m.childrenLockCounter.TransactionCount(txId); count > 0 {
+		return errors.Errorf("trying to release when children are still locked (has %d)", count)
+	}
+	if err := m.manager.Release(txId, m.name); err != nil {
+		return errors.Wrapf(err, "failed to release (%s,txId=%d)", m.name, txId)
+	}
+	if m.parent != nil {
+		m.parent.childrenLockCounter.RemoveReference(txId, m.lastNamePart)
+	}
+	return nil
+}
+
+func (m *MultiLevelLock) Promote(txId TransactionId, newLockType LockType) error {
+	prevLockType := m.manager.LockType(txId, m.name)
+	if prevLockType == newLockType {
+		return errors.New("lock type cannot be same")
+	}
+	if !LockTypesSubstitutable(prevLockType, newLockType) {
+		return errors.Errorf("lock types not substitutable (trying to substitute %s to %s)", prevLockType, newLockType)
+	}
+	if m.parent != nil {
+		parentLockType := m.manager.LockType(txId, m.parent.name)
+		if !LockTypesCanBeParent(parentLockType, newLockType) {
+			return errors.Errorf("incompatible lock type with parent (child %s, parent %s)", newLockType, parentLockType)
+		}
+	}
+	if err := m.manager.Promote(txId, m.name, newLockType); err != nil {
+		return errors.Wrapf(err, "failed to promote (%s,%s->%s,txId=%d)", m.name, prevLockType, newLockType, txId)
+	}
+
+	// All S/IS locks on descendents should be released if IS/IX -> SIX
+	if (prevLockType == ISLock || prevLockType == IXLock) && newLockType == SIXLock {
+		iterate := func(lock *MultiLevelLock) error {
+			return releaseLockIfSIS(txId, lock)
+		}
+		if err := traverseChildren(txId, m, &iterate); err != nil {
+			return errors.Wrap(err, "failed to release S/IS locks")
+		}
+	}
+
+	return nil
+}
+
+func (m *MultiLevelLock) Esclate(txId TransactionId) error {
+	prevLockType := m.manager.LockType(txId, m.name)
+	if prevLockType == SLock || prevLockType == XLock {
+		return nil
+	}
+	if prevLockType == NoLock {
+		return errors.New("no lock held")
+	}
+
+	toRelease := make([]ResourceName, 0)
+	traverseStep := func(lock *MultiLevelLock) error {
+		if lock != m && lock.manager.LockType(txId, lock.name) != NoLock {
+			toRelease = append(toRelease, lock.name)
+		}
+		return nil
+	}
+	traverseChildren(txId, m, &traverseStep)
+
+	var releaseErr error = nil
+	if m.manager.LockType(txId, m.name) == ISLock {
+		releaseErr = m.manager.AcquireThenRelease(txId, m.name, SLock, toRelease)
+	} else {
+		releaseErr = m.manager.AcquireThenRelease(txId, m.name, XLock, toRelease)
+	}
+	if releaseErr != nil {
+		return errors.Wrap(releaseErr, "failed to switch locks")
+	}
+
+	m.childrenLockCounter.ClearReferences(txId)
+	return nil
+}

--- a/database/concurrency/multiLevelLock.go
+++ b/database/concurrency/multiLevelLock.go
@@ -5,8 +5,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// Hierarchy: Market -> Symbol -> Page
-
 type MultiLevelLock struct {
 	name                ResourceName
 	lastNamePart        ResourceNamePart
@@ -41,6 +39,7 @@ func NewMultiLevelLock(manager *LockManager, parent *MultiLevelLock, key Resourc
 	lock := MultiLevelLock{
 		manager:             manager,
 		parent:              parent,
+		lastNamePart:        key,
 		childrenLockCounter: *NewTransactionRefCounter(),
 	}
 	if parent != nil && parent.manager != manager {
@@ -115,7 +114,7 @@ func (m *MultiLevelLock) Promote(txId TransactionId, newLockType LockType) error
 	if prevLockType == newLockType {
 		return errors.New("lock type cannot be same")
 	}
-	if !LockTypesSubstitutable(prevLockType, newLockType) {
+	if !LockTypesSubstitutable(newLockType, prevLockType) {
 		return errors.Errorf("lock types not substitutable (trying to substitute %s to %s)", prevLockType, newLockType)
 	}
 	if m.parent != nil {

--- a/database/concurrency/multiLevelLock.go
+++ b/database/concurrency/multiLevelLock.go
@@ -184,6 +184,12 @@ func (m *MultiLevelLock) printAllLocks(heading string) {
 	for txId, lock := range m.manager.getResourceEntry(m.name).locks {
 		fmt.Printf("%d/%s ", txId, lock.Type.String())
 	}
+	fmt.Printf("<- [")
+	queue := m.manager.getResourceEntry(m.name).queue.queue
+	for i := 0; i < queue.Len(); i++ {
+		at := queue.At(i).(lockRequest)
+		fmt.Printf("%d/%s ", at.Lock.Transaction, at.Lock.Type)
+	}
 	fmt.Printf("\n")
 	for _, child := range m.childrenLockCounter.children {
 		child.printAllLocks(heading + " ")

--- a/database/concurrency/multiLevelLock.go
+++ b/database/concurrency/multiLevelLock.go
@@ -1,6 +1,8 @@
 package concurrency
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
@@ -171,4 +173,19 @@ func (m *MultiLevelLock) Esclate(txId TransactionId) error {
 
 	m.childrenLockCounter.ClearReferences(txId)
 	return nil
+}
+
+func (m *MultiLevelLock) PrintAllLocks() {
+	m.printAllLocks("")
+}
+
+func (m *MultiLevelLock) printAllLocks(heading string) {
+	fmt.Printf("%s%s: ", heading, m.name.String())
+	for txId, lock := range m.manager.getResourceEntry(m.name).locks {
+		fmt.Printf("%d/%s ", txId, lock.Type.String())
+	}
+	fmt.Printf("\n")
+	for _, child := range m.childrenLockCounter.children {
+		child.printAllLocks(heading + " ")
+	}
 }

--- a/database/concurrency/multiLevelLock.go
+++ b/database/concurrency/multiLevelLock.go
@@ -47,9 +47,9 @@ func NewMultiLevelLock(manager *LockManager, parent *MultiLevelLock, key Resourc
 		panic("parent and child have different managers")
 	}
 	if parent != nil {
-		lock.name = parent.name.Child(key)
+		lock.name = parent.name.CreateChild(key)
 	} else {
-		lock.name = ResourceName(key)
+		lock.name = NewResourceName([]ResourceNamePart{key})
 	}
 	return &lock
 }

--- a/database/concurrency/name.go
+++ b/database/concurrency/name.go
@@ -3,6 +3,9 @@ package concurrency
 import (
 	"bytes"
 	"hash/fnv"
+	"strconv"
+
+	"github.com/jungnoh/mora/page"
 )
 
 func NewResourceNamePart(value string) ResourceNamePart {
@@ -69,4 +72,25 @@ func (r ResourceName) String() string {
 	}
 	buf.WriteString(">")
 	return buf.String()
+}
+
+func NewMarketResourceName(marketCode string) ResourceName {
+	return NewResourceName([]ResourceNamePart{
+		NewResourceNamePart(marketCode),
+	})
+}
+
+func NewCodeResourceName(marketCode, code string) ResourceName {
+	return NewResourceName([]ResourceNamePart{
+		NewResourceNamePart(marketCode),
+		NewResourceNamePart(code),
+	})
+}
+
+func NewSetResourceName(set page.CandleSet) ResourceName {
+	return NewResourceName([]ResourceNamePart{
+		NewResourceNamePart(set.MarketCode),
+		NewResourceNamePart(set.Code),
+		NewResourceNamePart(strconv.Itoa(int(set.Year))),
+	})
 }

--- a/database/concurrency/name.go
+++ b/database/concurrency/name.go
@@ -1,3 +1,19 @@
 package concurrency
 
+import "strings"
+
+type ResourceNamePart string
+
 type ResourceName string
+
+func (r ResourceName) Child(key ResourceNamePart) ResourceName {
+	return r + "/" + ResourceName(key)
+}
+
+func (r ResourceName) LastPart() ResourceNamePart {
+	lastIndex := strings.LastIndex(string(r), "/")
+	if lastIndex == -1 {
+		return ""
+	}
+	return ResourceNamePart(r[lastIndex+1:])
+}

--- a/database/concurrency/name.go
+++ b/database/concurrency/name.go
@@ -1,0 +1,10 @@
+package concurrency
+
+type resourceNamePart struct {
+	hash  uint64
+	value string
+}
+
+type ResourceName struct {
+	parts []resourceNamePart
+}

--- a/database/concurrency/name.go
+++ b/database/concurrency/name.go
@@ -1,10 +1,3 @@
 package concurrency
 
-type resourceNamePart struct {
-	hash  uint64
-	value string
-}
-
-type ResourceName struct {
-	parts []resourceNamePart
-}
+type ResourceName string

--- a/database/concurrency/types.go
+++ b/database/concurrency/types.go
@@ -1,0 +1,3 @@
+package concurrency
+
+type TransactionId uint64

--- a/database/database.go
+++ b/database/database.go
@@ -3,6 +3,7 @@ package database
 import (
 	"github.com/jungnoh/mora/common"
 	"github.com/jungnoh/mora/database/command"
+	"github.com/jungnoh/mora/database/concurrency"
 	"github.com/jungnoh/mora/database/storage"
 	"github.com/jungnoh/mora/database/util"
 	"github.com/jungnoh/mora/page"
@@ -12,43 +13,45 @@ import (
 type Database struct {
 	config  util.Config
 	Storage *storage.Storage
+	Lock    *concurrency.DatabaseLock
 }
 
 func NewDatabase(config util.Config) (*Database, error) {
 	db := Database{}
 	db.config = config
 	db.Storage = storage.NewStorage(&db.config)
+	db.Lock = concurrency.NewDatabaseLock()
 
 	return &db, nil
 }
-func (d *Database) Execute(commands []command.CommandContent) error {
+func (d *Database) Execute(commands []command.CommandContent) ([]interface{}, error) {
 	accessor, err := d.Storage.Access()
 	if err != nil {
-		return err
+		return []interface{}{}, err
 	}
-	defer accessor.RollbackIfActive()
+	tx := NewTransactionContext(&accessor, d.Lock)
+	defer tx.RollbackIfActive()
 
+	if err := tx.Start(); err != nil {
+		return []interface{}{}, errors.Wrapf(err, "failed to start")
+	}
+
+	result := make([]interface{}, 0, len(commands))
 	for _, cmd := range commands {
-		for _, set := range cmd.TargetSets() {
-			accessor.AddWrite(set)
+		cmdResult, err := tx.Execute(cmd)
+		if err != nil {
+			return []interface{}{}, errors.Wrapf(err, "failed to execute command '%s'", cmd.String())
 		}
+		result = append(result, cmdResult)
 	}
-	if err := accessor.Start(); err != nil {
-		return errors.Wrapf(err, "failed to start")
+	if err := tx.Commit(); err != nil {
+		return []interface{}{}, errors.Wrap(err, "failed to commit")
 	}
-	for _, cmd := range commands {
-		if err := accessor.Execute(cmd); err != nil {
-			return errors.Wrapf(err, "failed to execute command '%s'", cmd.String())
-		}
-	}
-	if err := accessor.Commit(); err != nil {
-		return errors.Wrap(err, "failed to commit")
-	}
-	return nil
+	return result, nil
 }
 
 // High level commands
-func (d *Database) Write(set page.CandleSetWithoutYear, candles common.CandleList) error {
+func (d *Database) Write(set page.CandleSetWithoutYear, candles common.CandleList) ([]interface{}, error) {
 	commands := CommandContentFactory{}.InsertToSet(set, candles)
 	return d.Execute(commands)
 }

--- a/database/storage/storage.go
+++ b/database/storage/storage.go
@@ -69,7 +69,6 @@ func (s *Storage) Access() (StorageAccessor, error) {
 		storage:  s,
 		started:  false,
 		finished: false,
-		todo:     make(map[string]accessorNeededPage),
 		readers:  make(map[string]*memImpl.MemoryReader),
 		writers:  make(map[string]*memImpl.MemoryWriter),
 	}

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -1,0 +1,69 @@
+package database
+
+import (
+	errSlice "github.com/carlmjohnson/errors"
+	"github.com/jungnoh/mora/database/command"
+	"github.com/jungnoh/mora/database/concurrency"
+	"github.com/jungnoh/mora/database/storage"
+	"github.com/pkg/errors"
+)
+
+type TransactionContext struct {
+	accessor *storage.StorageAccessor
+	dbLock   *concurrency.DatabaseLock
+	txId     concurrency.TransactionId
+	finished bool
+}
+
+func NewTransactionContext(accessor *storage.StorageAccessor, dbLock *concurrency.DatabaseLock) TransactionContext {
+	ctx := TransactionContext{
+		accessor: accessor,
+		dbLock:   dbLock,
+	}
+	return ctx
+}
+
+func (t *TransactionContext) Start() error {
+	txId, err := t.accessor.Start()
+	t.txId = concurrency.TransactionId(txId)
+	return err
+}
+
+func (t *TransactionContext) Execute(cmd command.CommandContent) (interface{}, error) {
+	neededLocks := cmd.NeededLocks()
+	for _, lock := range neededLocks {
+		lockType := concurrency.SLock
+		if lock.Exclusive {
+			lockType = concurrency.XLock
+		}
+		if err := t.dbLock.EnsureLock(t.txId, lock.Lock, lockType); err != nil {
+			return struct{}{}, errors.Wrapf(err, "failed to lock")
+		}
+	}
+	result, err := t.accessor.Execute(cmd)
+	if err != nil {
+		return result, errors.Wrapf(err, "failed to execute command '%s'", cmd.String())
+	}
+	return result, nil
+}
+
+func (t *TransactionContext) Commit() error {
+	t.finished = true
+	var errs errSlice.Slice
+	errs.Push(t.accessor.Commit())
+	errs.Push(t.dbLock.Free(t.txId))
+	return errs.Merge()
+}
+
+func (t *TransactionContext) Rollback() error {
+	t.finished = true
+	t.accessor.Rollback()
+	return t.dbLock.Free(t.txId)
+}
+
+func (t *TransactionContext) RollbackIfActive() {
+	if t.finished {
+		return
+	}
+	t.Rollback()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jungnoh/mora
 
-go 1.17
+go 1.18
 
 require (
 	github.com/ilyakaznacheev/cleanenv v1.2.6

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,10 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.0.0 // indirect
+	github.com/carlmjohnson/errors v0.0.7 // indirect
 	github.com/gammazero/deque v0.1.1 // indirect
 	github.com/joho/godotenv v1.4.0 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 
 require (
 	github.com/BurntSushi/toml v1.0.0 // indirect
+	github.com/gammazero/deque v0.1.1 // indirect
 	github.com/joho/godotenv v1.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	olympos.io/encoding/edn v0.0.0-20201019073823-d3554ca0b0a3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
+github.com/carlmjohnson/errors v0.0.7 h1:+Kk4yTaoUOJrODLdUs8uzJRqSAS4Gga+p4++TIjFyFs=
+github.com/carlmjohnson/errors v0.0.7/go.mod h1:QVeWxzdj25lTk9lCjw8LNLCeXzUG9UwXAwPpRL0UQ8E=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/gammazero/deque v0.1.1 h1:xRVkDuSvDmFuMGf3IquHuRc2jlL0+v/WpFCWaauzwbE=
 github.com/gammazero/deque v0.1.1/go.mod h1:KQw7vFau1hHuM8xmI9RbgKFbAsQFWmBpqQ2KenFLk6M=
@@ -40,6 +42,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.0.0 h1:dtDWrepsVPfW9H/4y7dDgFc2MBUSeJhlaDtK13CxFlU=
 github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/gammazero/deque v0.1.1 h1:xRVkDuSvDmFuMGf3IquHuRc2jlL0+v/WpFCWaauzwbE=
+github.com/gammazero/deque v0.1.1/go.mod h1:KQw7vFau1hHuM8xmI9RbgKFbAsQFWmBpqQ2KenFLk6M=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/ilyakaznacheev/cleanenv v1.2.6 h1:oJRaVZfAI0xdA5LJNguuKH2ldVJg44SP8GqkEn/cw7w=
 github.com/ilyakaznacheev/cleanenv v1.2.6/go.mod h1:C3bB+MJ+LjECYlw2k7CSagKGfL1Ym2ywfjj40RjXJ24=


### PR DESCRIPTION
Added multilevel locking with multiple granularity. Granularity levels are `X -> SIX -> S -> IX -> IS`

### TODO
- Unify types that are interchangeable between lock and storage (TransactionId, ResourceName, ..)
- Redefine commands to be more predictable (needed for effecient WAL) and extensible
- Add analysis commands
- Add deadlock detector